### PR TITLE
Chapter 5 exercises

### DIFF
--- a/src/lab5.py
+++ b/src/lab5.py
@@ -23,6 +23,9 @@ BLOCK_ELEMENTS = [
     "legend", "details", "summary"
 ]
 
+INDENT_PX = 20  
+BULLET_SIZE = 8
+
 @wbetools.patch(Layout)
 class BlockLayout:
     def __init__(self, node, parent, previous):
@@ -41,6 +44,10 @@ class BlockLayout:
 
         self.x = self.parent.x
         self.width = self.parent.width
+
+        if isinstance(self.node, Element) and self.node.tag == "li":
+            self.x += INDENT_PX
+            self.width -= INDENT_PX
 
         if self.previous:
             self.y = self.previous.y + self.previous.height
@@ -120,10 +127,22 @@ class BlockLayout:
             rect = DrawRect(self.x, self.y, x2, y2, "gray")
             cmds.append(rect)
 
-        if isinstance(self.node, Element) and self.node.tag == "nav" and\
+        elif isinstance(self.node, Element) and self.node.tag == "nav" and\
             has_attribute(self.node, "class", "links"):
             x2, y2 = self.x + self.width, self.y + self.height
             rect = DrawRect(self.x, self.y, x2, y2, "#e0e0e0")  # light gray
+            cmds.append(rect)
+        
+        elif isinstance(self.node, Element) and self.node.tag == "li":
+            bullet_x = self.x - INDENT_PX + 4  
+            bullet_y = self.y + 4  
+            rect = DrawRect(
+                bullet_x,
+                bullet_y,
+                bullet_x + BULLET_SIZE,
+                bullet_y + BULLET_SIZE,
+                "black"
+            )
             cmds.append(rect)
 
         if self.layout_mode() == "inline":
@@ -238,7 +257,8 @@ class Browser:
         self.draw()
 
 if __name__ == "__main__":
-    import sys
+    import sys 
     # Browser().load(URL(sys.argv[1]))
-    Browser().load(URL('https://browser.engineering/layout.html'))
+    # Browser().load(URL('https://browser.engineering/layout.html'))
+    Browser().load(URL('file:///Users/li016390/Desktop/challenges/test.html'))
     tkinter.mainloop()

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -60,6 +60,7 @@ class BlockLayout:
             self.weight = "normal"
             self.style = "roman"
             self.size = 12
+            self.in_pre = False
 
             self.line = []
             self.recurse(self.node)
@@ -115,6 +116,12 @@ class BlockLayout:
         if isinstance(self.node, Element) and self.node.tag == "pre":
             x2, y2 = self.x + self.width, self.y + self.height
             rect = DrawRect(self.x, self.y, x2, y2, "gray")
+            cmds.append(rect)
+
+        if isinstance(self.node, Element) and self.node.tag == "nav" and\
+            has_attribute(self.node, "class", "links"):
+            x2, y2 = self.x + self.width, self.y + self.height
+            rect = DrawRect(self.x, self.y, x2, y2, "#e0e0e0")  # light gray
             cmds.append(rect)
 
         if self.layout_mode() == "inline":
@@ -200,6 +207,11 @@ def paint_tree(layout_object, display_list):
     for child in layout_object.children:
         paint_tree(child, display_list)
 
+def has_attribute(html_node, attr_name, attr_value):
+    return attr_name in html_node.attributes and\
+        html_node.attributes[attr_name] == attr_value
+    
+
 @wbetools.patch(Browser)
 class Browser:
     def load(self, url):
@@ -225,5 +237,6 @@ class Browser:
 
 if __name__ == "__main__":
     import sys
-    Browser().load(URL(sys.argv[1]))
+    # Browser().load(URL(sys.argv[1]))
+    Browser().load(URL('https://browser.engineering/layout.html'))
     tkinter.mainloop()

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -1,7 +1,7 @@
 """
 This file compiles the code in Web Browser Engineering,
 up to and including Chapter 5 (Laying out Pages),
-without exercises.
+Including exercises implemented by Tal Langus.
 """
 
 import wbetools
@@ -279,7 +279,5 @@ class Browser:
 
 if __name__ == "__main__":
     import sys 
-    # Browser().load(URL(sys.argv[1]))
-    Browser().load(URL('https://browser.engineering/layout.html'))
-    # Browser().load(URL('file:///Users/li016390/Desktop/challenges/test.html'))
+    Browser().load(URL(sys.argv[1]))
     tkinter.mainloop()

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -51,6 +51,8 @@ class BlockLayout:
         if mode == "block":
             previous = None
             for child in self.node.children:
+                if isinstance(child, Element) and child.tag == "head":
+                    continue
                 next = BlockLayout(child, self, previous)
                 self.children.append(next)
                 previous = next


### PR DESCRIPTION
Implemented support for rendering the \<nav class="links"> element with a light gray background to mimic the links bar styling in real browsers.

Modified layout engine to exclude the \<head> element and its children from the layout tree while keeping them in the DOM tree, effectively hiding scripts, styles, and titles from rendering.

Added visual styling for \<li> elements by rendering left-aligned square bullets and indenting the text to appear to the right of the bullet point.

Injected a “Table of Contents” label with a gray background above the \<nav id="toc"> list without modifying the lexer or parser, using layout-time DOM inspection.