### PR TITLE
Chapter 6 exercises

### DIFF
--- a/src/browser6.css
+++ b/src/browser6.css
@@ -42,10 +42,3 @@ fieldset { display: block; }
 legend { display: block; }
 details { display: block; }
 summary { display: block; }
-
-
-.red-block    { background-color: red;    width: 320px; height: 120px; }
-.green-block  { background-color: green;  width: 180px; height: 100px; }
-.blue-block   { background-color: blue;   width: 220px; height: 80px; }
-.yellow-block { background-color: yellow; width: 400px; height: 60px; }
-.gray-block   { background-color: gray;   width: 250px; height: 150px; }

--- a/src/browser6.css
+++ b/src/browser6.css
@@ -5,3 +5,4 @@ i { font-style: italic; }
 b { font-weight: bold; }
 small { font-size: 90%; }
 big { font-size: 110%; }
+code { font-family: Courier;}

--- a/src/browser6.css
+++ b/src/browser6.css
@@ -1,8 +1,51 @@
 pre { background-color: gray; }
-
 a { color: blue; }
 i { font-style: italic; }
 b { font-weight: bold; }
 small { font-size: 90%; }
 big { font-size: 110%; }
 code { font-family: Courier;}
+html { display: block; }
+body { display: block; }
+article { display: block; }
+section { display: block; }
+nav { display: block; }
+aside { display: block; }
+h1 { display: block; }
+h2 { display: block; }
+h3 { display: block; }
+h4 { display: block; }
+h5 { display: block; }
+h6 { display: block; }
+hgroup { display: block; }
+header { display: block; }
+footer { display: block; }
+address { display: block; }
+p { display: block; }
+hr { display: block; }
+pre { display: block; }
+blockquote { display: block; }
+ol { display: block; }
+ul { display: block; }
+menu { display: block; }
+li { display: block; }
+dl { display: block; }
+dt { display: block; }
+dd { display: block; }
+figure { display: block; }
+figcaption { display: block; }
+main { display: block; }
+div { display: block; }
+table { display: block; }
+form { display: block; }
+fieldset { display: block; }
+legend { display: block; }
+details { display: block; }
+summary { display: block; }
+
+
+.red-block    { background-color: red;    width: 320px; height: 120px; }
+.green-block  { background-color: green;  width: 180px; height: 100px; }
+.blue-block   { background-color: blue;   width: 220px; height: 80px; }
+.yellow-block { background-color: yellow; width: 400px; height: 60px; }
+.gray-block   { background-color: gray;   width: 250px; height: 150px; }

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -46,7 +46,11 @@ class BlockLayout:
         wbetools.record("layout_pre", self)
         height_offset = 0
         self.x = self.parent.x
-        self.width = self.parent.width
+
+        width = self.node.style.get("width", "auto")
+        if width.endswith("px"):
+            self.width = int(width[:-2])
+        else: self.width = self.parent.width
 
         if isinstance(self.node, Element) and self.node.tag == "li":
             self.x += INDENT_PX
@@ -85,12 +89,17 @@ class BlockLayout:
 
         for child in self.children:
             child.layout()
+        
 
-        if mode == "block":
-            self.height = sum([
-                child.height for child in self.children]) + height_offset
+        height = self.node.style.get("height", "auto")
+        if height.endswith("px"):
+            self.height = int(height[:-2])
         else:
-            self.height = self.cursor_y
+            if mode == "block":
+                self.height = sum([
+                    child.height for child in self.children]) + height_offset
+            else:
+                self.height = self.cursor_y
 
         wbetools.record("layout_post", self)
 

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -14,15 +14,6 @@ from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser, Layout, Browser
 
-BLOCK_ELEMENTS = [
-    "html", "body", "article", "section", "nav", "aside",
-    "h1", "h2", "h3", "h4", "h5", "h6", "hgroup", "header",
-    "footer", "address", "p", "hr", "pre", "blockquote",
-    "ol", "ul", "menu", "li", "dl", "dt", "dd", "figure",
-    "figcaption", "main", "div", "table", "form", "fieldset",
-    "legend", "details", "summary"
-]
-
 LIST_ELEMENTS= ["ul", "ol", "menu"]
 
 INDENT_PX = 20  
@@ -107,7 +98,7 @@ class BlockLayout:
         if isinstance(self.node, Text):
             return "inline"
         elif any([isinstance(child, Element) and \
-                  child.tag in BLOCK_ELEMENTS
+                  child.style['display'] == 'block'
                   for child in self.node.children]):
             return "block"
         elif self.node.children:

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -327,6 +327,7 @@ class Browser:
         self.nodes = HTMLParser(body).parse()
 
         rules = DEFAULT_STYLE_SHEET.copy()
+        
         links = [node.attributes["href"]
                  for node in tree_to_list(self.nodes, [])
                  if isinstance(node, Element)
@@ -340,6 +341,15 @@ class Browser:
             except:
                 continue
             rules.extend(CSSParser(body).parse())
+        
+        inline_stlyes = [node
+                 for node in tree_to_list(self.nodes, [])
+                 if isinstance(node, Element)
+                 and node.tag == "style"]
+        for node in inline_stlyes:
+            text = node.children[0].text
+            rules.extend(CSSParser(text).parse())
+        
         style(self.nodes, sorted(rules, key=cascade_priority))
 
         self.document = DocumentLayout(self.nodes)

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -13,7 +13,7 @@ from lab1 import URL
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
-from lab5 import BLOCK_ELEMENTS, DrawRect, DrawText, paint_tree
+from lab5 import DrawRect, DrawText, paint_tree
 from lab5 import BlockLayout, DocumentLayout, Browser
 import wbetools
 
@@ -188,6 +188,7 @@ INHERITED_PROPERTIES = {
     "font-style": "normal",
     "font-weight": "normal",
     "color": "black",
+    "display": "inline",
 }
 
 def style(node, rules):

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -101,11 +101,12 @@ class CSSParser:
         return pairs
 
     def selector(self):
-        out = TagSelector(self.word().casefold())
+        word = self.word()
+        out = get_discrete_selector(word.casefold())
         self.whitespace()
         while self.i < len(self.s) and self.s[self.i] != "{":
-            tag = self.word()
-            descendant = TagSelector(tag.casefold())
+            word = self.word()
+            descendant = get_discrete_selector(word.casefold())
             out = DescendantSelector(out, descendant)
             self.whitespace()
         return out
@@ -142,6 +143,27 @@ class TagSelector:
     def __repr__(self):
         return "TagSelector(tag={}, priority={})".format(
             self.tag, self.priority)
+
+class ClassSelector:
+    def __init__(self, class_name):
+        self.class_name = class_name
+        self.priority = 10  
+
+    def matches(self, node):
+        if not isinstance(node, Element): return False
+        classes = node.attributes.get("class", "").split()
+        return self.class_name in classes
+
+    @wbetools.js_hide
+    def __repr__(self):
+        return "ClassSelector(class_name={}, priority={})".format(
+            self.class_name, self.priority)
+
+def get_discrete_selector(word):
+    if word.startswith("."):
+        return ClassSelector(word[1:])
+    else:
+        return TagSelector(word.casefold())
 
 class DescendantSelector:
     def __init__(self, ancestor, descendant):

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -215,7 +215,8 @@ class BlockLayout:
         style = node.style["font-style"]
         if style == "normal": style = "roman"
         size = int(float(node.style["font-size"][:-2]) * .75)
-        font = get_font(size, weight, style)
+        family = node.style.get("font-family")
+        font = get_font(size, weight, style, family)
 
         w = font.measure(word)
         if self.cursor_x + w > self.width:
@@ -294,6 +295,8 @@ class Browser:
 
         self.scroll = 0
         self.window.bind("<Down>", self.scrolldown)
+        self.window.bind("<Up>", self.scrollup)
+        self.window.bind("<MouseWheel>", self.on_mousewheel)
         self.display_list = []
 
     def load(self, url):
@@ -324,5 +327,7 @@ class Browser:
 
 if __name__ == "__main__":
     import sys
-    Browser().load(URL(sys.argv[1]))
+    # Browser().load(URL(sys.argv[1]))
+    # Browser().load(URL('https://browser.engineering/styles.html'))
+    Browser().load(URL('file:///Users/li016390/Desktop/challenges/test.html'))
     tkinter.mainloop()


### PR DESCRIPTION
Implemented the font-family property as an inheritable CSS attribute and applied a monospaced font (e.g., Courier) to \<code> elements, using a font cache for performance.

Added support for width and height properties in block layout, accepting either pixel values or auto to defer to the default layout behavior.

Implemented CSS class selectors (.classname) that apply to elements with matching class attributes, overriding tag selectors and enabling syntax highlighting for code blocks.

Introduced support for the display property, replacing the hard-coded block elements list with a default inline value defined in the browser's user-agent style sheet.

Enabled inline <style> tag support for embedded style sheets, applying them in DOM order after external stylesheets without modifying the HTML parser.

Added support for the :has pseudo-class, enabling ancestor styling based on descendant presence.